### PR TITLE
bug fix. the import name was wrong.

### DIFF
--- a/sphinx_qsp/quickstart_plus.py
+++ b/sphinx_qsp/quickstart_plus.py
@@ -29,7 +29,7 @@ import json
 import os
 
 from sphinx import quickstart
-from sphinx.quickstart import ask_user, generate, do_prompt, nonempty, boolean
+from sphinx.cmd.quickstart import ask_user, generate, do_prompt, nonempty, boolean
 
 __version__ = "0.6"
 


### PR DESCRIPTION
As it's written in the code of quickstart.py.
the package name has changed to `sphinx.cmd.quickstart`.
So I just replaced the path from `sphinx.quickstart` to `sphinx.cmd.quickstart`.

more details, please refer to here!
https://github.com/sphinx-doc/sphinx/blob/master/sphinx/quickstart.py